### PR TITLE
Fix doble POST

### DIFF
--- a/app/Http/Controllers/IndexController.php
+++ b/app/Http/Controllers/IndexController.php
@@ -71,6 +71,6 @@ class IndexController extends Controller
 
         curl_exec($ch);
         curl_close($ch);
-        return redirect('/');
+        return redirect()->to('/');
     }
 }


### PR DESCRIPTION
Se arregló el codigo para que no se manda dos veces el POST, forzando el metodo GET en el redirect luego del form.